### PR TITLE
Gitconfig: core.whitespace configuration for git diff

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -27,6 +27,9 @@
     # OS X users only!
     # askpass = /PATH/TO/YOUR/HOME/FOLDER/git-password
 
+    # Highlight whitespace errors in git diff:
+    whitespace = tabwidth=4,tab-in-indent,cr-at-eol,trailing-space
+
 # GitHub credentials
 [github]
     user = YOUR GITHUB USERNAME


### PR DESCRIPTION
The `core.whitespace` configuration impacts the highlighting in git diff.
This configuration highlights things as errors such as tabs instead of spaces, trailing whitespace or non-unix line endings.

See the [git help](http://www.kernel.org/pub/software/scm/git/docs/git-config.html#hdlist1) for details:

_core.whitespace_
A comma separated list of common whitespace problems to notice. git diff will use color.diff.whitespace to highlight them, and git apply --whitespace=error will consider them as errors. You can prefix - to disable any of them (e.g. -trailing-space):
- blank-at-eol treats trailing whitespaces at the end of the line as an error (enabled by default).
- space-before-tab treats a space character that appears immediately before a tab character in the initial indent part of the line as an error (enabled by default).
- indent-with-non-tab treats a line that is indented with 8 or more space characters as an error (not enabled by default).
- tab-in-indent treats a tab character in the initial indent part of the line as an error (not enabled by default).
- blank-at-eof treats blank lines added at the end of file as an error (enabled by default).
- trailing-space is a short-hand to cover both blank-at-eol and blank-at-eof.
- cr-at-eol treats a carriage-return at the end of line as part of the line terminator, i.e. with it, trailing-space does not trigger if the character before such a carriage-return is not a whitespace (not enabled by default).
- tabwidth=<n> tells how many character positions a tab occupies; this is relevant for indent-with-non-tab and when git fixes tab-in-indent errors. The default tab width is 8. Allowed values are 1 to 63.
