### PR TITLE
Gitconfig: add browse alias

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -16,7 +16,10 @@
     br = branch
     co = checkout
     lga = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)%Creset' --abbrev-commit --date=relative --branches --remotes
+
+    # "git weburl" prints the URL of the github project page for repositories hosted on github.
     weburl = !git config --get remote.origin.url | sed -e 's/git:\\/\\/github.com/https:\\/\\/github.com/' -e 's/git@github.com:/https:\\/\\/github.com\\//' -e 's/\\.git$//'
+    # "git browse" opens the github project page of this repository in the browser.
     browse = !open `git weburl`
 
 


### PR DESCRIPTION
When executing `git browse` within a github repository, a browser (-tab) is opened with the project on github.
Not sure whether the `open` command works on non-osx though.
