### PR TITLE
Remove plone.org as a release target from .pypirc

### DIFF
--- a/.pypirc
+++ b/.pypirc
@@ -7,11 +7,3 @@ index-servers =
 [pypi]
 username:YOUR PYPI USERNAME
 password:YOUR PYPI PASSWORD
-
-# Support plone.org as an alternative target for releases.
-# To use while releasing, use "-r plone.org" with setup.py register/upload,
-# or "-d plone.org" with jarn.mkrelease.
-[plone.org]
-repository:http://plone.org/products
-username:YOUR PLONE.ORG USERNAME
-password:YOUR PLONE.ORG PASSWORD


### PR DESCRIPTION
plone.org no longer has a products section, can this be removed?